### PR TITLE
Support Play's hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ Usage
 Add the below line to your `build.sbt`:
 
 ```
-libraryDependencies += "io.github.tanin47" %% "play-json-form" % "1.1.0"
+libraryDependencies += "io.github.tanin47" %% "play-json-form" % "1.1.1"
 ```
+
+DO NOT use 1.1.0 because it doesn't work with PlayFramework's hot reload mechanism.
 
 The artifacts are hosted here: https://bintray.com/givers/maven/play-json-form
 
@@ -207,5 +209,6 @@ Develop
 --------
 
 1. Run `sbt generator/run` in order to generate the classes in `givers.form.generated`.
-2. Run `sbt test` to run all tests
-3. Run `sbt clean publishSigned` to publish
+2. Run `sbt test` to run all tests.
+3. Run `sbt clean publishSigned sonaUpload` to publish.
+4. Go to https://central.sonatype.com/publishing and publish the new version.

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 name := "play-json-form"
-version := "1.1.0"
+version := "1.1.1"
 
 lazy val generator = (project in file("generator"))
   .settings(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.0-RC2
+sbt.version=1.11.0

--- a/src/main/scala/givers/form/ObjectMappingList.scala
+++ b/src/main/scala/givers/form/ObjectMappingList.scala
@@ -9,9 +9,10 @@ import scala.util.Try
 
 class ObjectMappingList[T: TypeTag: ClassTag](val fields: Seq[Field[_]]) extends ObjectMapping[T] {
 
-  private[this] val rm = runtimeMirror(getClass.getClassLoader)
-
   def apply(values: Seq[_]): T = {
+    // Due to Play's auto-reload. We'll have to re-fetch the class loader every time.
+    // This is because Play's auto-reload replace the class loader with a new one every time the code is changed.
+    val rm = runtimeMirror(getClass.getClassLoader)
     val tpe = typeOf[T]
     val classSymbol = tpe.typeSymbol.asClass
 
@@ -38,6 +39,9 @@ class ObjectMappingList[T: TypeTag: ClassTag](val fields: Seq[Field[_]]) extends
   }
 
   def unapply(value: T): Seq[_] = {
+    // Due to Play's auto-reload. We'll have to re-fetch the class loader every time.
+    // This is because Play's auto-reload replace the class loader with a new one every time the code is changed.
+    val rm = runtimeMirror(getClass.getClassLoader)
     val instance = rm.reflect(value)
     val fields = typeOf[T].members.sorted.collect { case m: (MethodSymbol @unchecked) if m.isCaseAccessor => m }.toList
     fields.map { f => instance.reflectMethod(f).apply() }


### PR DESCRIPTION
We've encountered an obscure ClassNotFound error. Cursor told us that: 

```
ERROR 14:27:33 f.ErrorHandler - ⏎ ! @89i09e39i - Internal server error, for (POST) [/task/task_AkULEhAAzaHmu3NXpJxU73/update-task] -> ⏎ play.api.http.HttpErrorHandlerExceptions$$anon$1: Execution exception[[ClassNotFoundException: controllers.TaskController$]] ⏎ at play.api.http.HttpErrorHandlerExceptions$.$anonfun$convertToPlayException$2(HttpErrorHandler.scala:400) ⏎ at scala.Option.map(Option.scala:242) ⏎ at play.api.http.HttpErrorHandlerExceptions$.convertToPlayException(HttpErrorHandler.scala:398) ⏎ at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:390) ⏎ at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:267) ⏎ at framework.ErrorHandler.onServerError(ErrorHandler.scala:124) ⏎ at framework.LoggingFilter$$anonfun$apply$5.applyOrElse(LoggingFilter.scala:37) ⏎ at framework.LoggingFilter$$anonfun$apply$5.applyOrElse(LoggingFilter.scala:36) ⏎ at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:490) ⏎ at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63) ⏎ at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100) ⏎ at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18) ⏎ at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94) ⏎ at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100) ⏎ at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49) ⏎ at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48) ⏎ at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387) ⏎ at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1310) ⏎ at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841) ⏎ at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806) ⏎ at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188) ⏎ Caused by: java.lang.ClassNotFoundException: controllers.TaskController$ ⏎ at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445) ⏎ at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593) ⏎ at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ⏎ at java.base/java.lang.Class.forName0(Native Method) ⏎ at java.base/java.lang.Class.forName(Class.java:534) ⏎ at java.base/java.lang.Class.forName(Class.java:513) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror.javaClass(JavaMirrors.scala:611) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$classToJava$1(JavaMirrors.scala:1299) ⏎ at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toJava(TwoWayCaches.scala:61) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror.classToJava(JavaMirrors.scala:1291) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$classToJava$1(JavaMirrors.scala:1306) ⏎ at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toJava(TwoWayCaches.scala:61) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror.classToJava(JavaMirrors.scala:1291) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror.$anonfun$constructorToJava$1(JavaMirrors.scala:1371) ⏎ at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toJava(TwoWayCaches.scala:61) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror.constructorToJava(JavaMirrors.scala:1370) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaMethodMirror.jconstr$lzycompute(JavaMirrors.scala:388) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaMethodMirror.jconstr(JavaMirrors.scala:388) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaMethodMirror.jinvokeraw(JavaMirrors.scala:392) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaMethodMirror.jinvoke(JavaMirrors.scala:395) ⏎ at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaVanillaMethodMirror.apply(JavaMirrors.scala:411) ⏎ at givers.form.ObjectMappingList.apply(ObjectMappingList.scala:37) ⏎ at givers.form.ObjectMappingList.$anonfun$bind$1(ObjectMappingList.scala:47) ⏎ at scala.util.Success.map(Try.scala:270) ⏎ at givers.form.ObjectMappingList.bind(ObjectMappingList.scala:47) ⏎ at givers.form.ValueMapping.bind(Mapping.scala:100) ⏎ at givers.form.ValueMapping.bind$(Mapping.scala:98) ⏎ at givers.form.ObjectMappingList.bind(ObjectMappingList.scala:10) ⏎ at givers.form.Form.bind(Form.scala:32) ⏎ at givers.form.Form.bindFromRequest(Form.scala:25) ⏎ at controllers.TaskController.$anonfun$updateTask$2(TaskController.scala:462) ⏎ at scala.util.Either.fold(Either.scala:197) ⏎ at play.api.mvc.ActionRefiner.$anonfun$invokeBlock$3(Action.scala:533) ⏎ at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:470) ⏎ ... 12 common frames omitted ⏎
```